### PR TITLE
 Issue #24 - Misaligned timestamp in system messages

### DIFF
--- a/src/components/consultation/SystemMessage/system-message.scss
+++ b/src/components/consultation/SystemMessage/system-message.scss
@@ -33,7 +33,7 @@
     }
   }
   &__time {
-    align-self: flex-end;
+    align-self: center;
     padding-left: 0.6rem;
   }
 }


### PR DESCRIPTION
Issue reference: [https://github.com/UNICEFECAR/USupport-entry-bundle/issues/24](https://github.com/UNICEFECAR/USupport-entry-bundle/issues/24)